### PR TITLE
Speed up zp_kb.py by several orders of magnitude

### DIFF
--- a/src/scripts/zp_kb.py
+++ b/src/scripts/zp_kb.py
@@ -122,28 +122,34 @@ preamble = """@prefix : <http://zfin.org/zp/annotations#> .
 #################################################################
 
 """
-main = ""
-
 iris = list(set(kb[kb.IRI.notnull()]["IRI"]))
 ###  http://purl.obolibrary.org/obo/ZP_0021318
+
+text_file = open(annotation_ttl, "w")
+text_file.write(preamble)
+
+zfin_eqstring_by_iri = {}
+for row in kb.itertuples():
+    zfin_eqstring_by_iri[row.IRI] = row.ANID
+
 for iri in iris:
-    main += """
+    text_file.write("""
 <%s> rdf:type owl:Class ;
         :hasX "%s" . 
 
-""" % (iri,kb[kb.IRI==iri]['ANID'].iloc[0])
+""" % (iri,zfin_eqstring_by_iri[iri]))
 
-main += """
+text_file.write("""
 #################################################################
 #    Individuals
 #################################################################
 
-"""
+""")
 
 ###  http://www.semanticweb.org/matentzn/ontologies/2018/9/untitled-ontology-320#testI
 
-for index, row in kb.iterrows():
-   main += """
+for row in kb.itertuples():
+    text_file.write("""
 :ZPK_%s rdf:type owl:NamedIndividual ,
         [ rdf:type owl:Restriction ;
           owl:onProperty :hasPhenotype ;
@@ -159,13 +165,9 @@ for index, row in kb.iterrows():
         :hasPUBLICATIONID "%s" ;
         :hasFIGUREID "%s" .
 
-""" % (row['ZFINID'], row['IRI'], row['ZFINID'], row['GENEID'], row['PHENOTYPETAG'], row['FISHID'], row['STARTSTAGEID'], row['ENDSTAGEID'], row['FISHENVIRONMENTID'], row['PUBLICATIONID'], row['FIGUREID'])
-
-o = preamble + main
+""" % (row.ZFINID, row.IRI, row.ZFINID, row.GENEID, row.PHENOTYPETAG, row.FISHID, row.STARTSTAGEID, row.ENDSTAGEID, row.FISHENVIRONMENTID, row.PUBLICATIONID, row.FIGUREID))
 
 # Export KB and gene_annotation to ZP mappings.
-text_file = open(annotation_ttl, "w")
-text_file.write("%s" % o)
 text_file.close()
 kb.to_csv(gene_annotation_mappings, sep = '\t', index=False)
 


### PR DESCRIPTION
This commit optimizes the zp_kb.py script, to the point where the majority of running time is spent downloading data from zfin.

1. Previously, assigning a ZFIN EQ string to a ZP URI used an O(n^2) algorithm. For a given URI, the script would iterate through every row in the dataframe to find matching ZP URIs, and then take the ZFIN EQ string from the first matching row. (They are all the same).

This commit iterates through the dataframe once and indexes ZFIN EQ strings by ZP URI in one go.

2. This commit also changes the use of `.iterrows` to `.itertuples` when iterating over the rows of the dataframe to avoid needlessly creating a `Series` object.

3. Finally, this commit gets rid of two slow spots, where a string was being concatenated for every row in the dataframe (which created lots of needless copies of strings). Instead, output is progressively written to the outfile.